### PR TITLE
Update fluent-bit-configmap.yaml

### DIFF
--- a/fluent-bit-configmap.yaml
+++ b/fluent-bit-configmap.yaml
@@ -52,11 +52,11 @@ data:
     
     # Rename and add fields to be valid against the GELF format.
     # See http://docs.graylog.org/en/2.5/pages/gelf.html
-    # Keep the "time" field, as it is not a timestamp.
     [FILTER]
         Name modify
         Match *
         Rename log short_message
+        Rename date timestamp
         Rename stream _stream
         Rename timestamp _timestamp
         Rename pod_name _k8s_pod_name
@@ -94,7 +94,6 @@ data:
         Format      json
         Time_Key    time
         Time_Format %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep   On
         # Command      |  Decoder | Field | Optional Action
         # =============|==================|=================
         Decode_Field_As   escaped    log

--- a/fluent-bit-configmap.yaml
+++ b/fluent-bit-configmap.yaml
@@ -50,28 +50,12 @@ data:
         Operation lift
         Nested_under kubernetes
     
-    # Rename and add fields to be valid against the GELF format.
-    # See http://docs.graylog.org/en/2.5/pages/gelf.html
-    [FILTER]
-        Name modify
-        Match *
-        Rename log short_message
-        Rename date timestamp
-        Rename stream _stream
-        Rename timestamp _timestamp
-        Rename pod_name _k8s_pod_name
-        Rename namespace_name _k8s_namespace_name
-        Rename pod_id _k8s_pod_id
-        Rename labels _k8s_labels
-        Rename container_name _k8s_container_name
-        Rename docker_id _docker_id
-        Add version 1.1
-    
-    # Remove useless fields
+    # Remove offending fields, see: https://github.com/fluent/fluent-bit/issues/1291
     [FILTER]
         Name record_modifier
         Match *
         Remove_key annotations
+        Remove_key labels
 
   output-graylog.conf: |
     [OUTPUT]


### PR DESCRIPTION
Taking this `lift`ed, yet un`modify`d log:
```json
  {
    "annotations": {
      "cni.projectcalico.org/podIP": "10.42.4.49/32",
      "prometheus.io/path": "/api/v1/metrics/prometheus",
      "prometheus.io/port": "2020",
      "prometheus.io/scrape": "true"
    },
    "container_name": "fluent-bit",
    "date": 1555797738.084483,
    "docker_id": "a3ee27d003c223037a6b34e9810b49e1588adade71760bdc9220e32a451b5252",
    "host": "165.22.141.35",
    "labels": {
      "controller-revision-hash": "7cffd9d7bc",
      "k8s-app": "fluent-bit-logging",
      "kubernetes.io/cluster-service": "true",
      "pod-template-generation": "1",
      "version": "v1"
    },
    "log": "[2019/04/20 22:02:18] [error] [out_gelf] error encoding to GELF",
    "namespace_name": "logging",
    "pod_id": "f41ca02c-63b7-11e9-a252-be914d40b130",
    "pod_name": "fluent-bit-pppm5",
    "stream": "stderr",
    "time": "2019-04-20T22:02:18.084483069Z"
  },
```

`date` is just what [GELF 1.1](http://docs.graylog.org/en/2.5/pages/gelf.html) expects: 
> timestamp number: Seconds since UNIX epoch with optional decimal places for milliseconds; SHOULD be set by client library. Will be set to the current timestamp (now) by the server if absent.

NO need to keep the time field from the docker parser.