### PR TITLE
fixed [error] [flb_msgpack_to_gelf] missing short_message key

### DIFF
--- a/fluent-bit-configmap.yaml
+++ b/fluent-bit-configmap.yaml
@@ -40,7 +40,7 @@ data:
         Kube_URL            https://kubernetes.default.svc.cluster.local:443
         Merge_Log           On
         K8S-Logging.Parser  On
-    
+
     # ${HOSTNAME} returns the host name.
     # But Fluentbit runs in a container. So, it is not meaningful.
     # Instead, copy the host name from the Kubernetes object.
@@ -49,7 +49,7 @@ data:
         Match *
         Operation lift
         Nested_under kubernetes
-    
+
     # Remove offending fields, see: https://github.com/fluent/fluent-bit/issues/1291
     [FILTER]
         Name record_modifier
@@ -64,7 +64,7 @@ data:
         Host          192.168.1.18
         Port          12201
         Mode          tcp
-        Gelf_Short_Message_Key short_message
+        Gelf_Short_Message_Key log
 
   parsers.conf: |
     [PARSER]


### PR DESCRIPTION
after removing   
``` [FILTER]		
         Name modify		
         Match *		
         Rename log short_message		
         Rename date timestamp		
         Rename stream _stream		
         Rename timestamp _timestamp		
         Rename pod_name _k8s_pod_name		
         Rename namespace_name _k8s_namespace_name		
         Rename pod_id _k8s_pod_id		
         Rename labels _k8s_labels		
         Rename container_name _k8s_container_name		
         Rename docker_id _docker_id		
         Add version 1.1
```
there is no short_message variable